### PR TITLE
fix(Hono): use `RegExpRouter` as a router

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "baojs": "^0.1.3",
     "bunrest": "^1.0.5",
     "colstonjs": "latest",
-    "hono": "^2.0.8",
+    "hono": "^2.0.9",
     "kingworld": "^0.0.0-experimental.21"
   }
 }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
+import { RegExpRouter } from 'hono/router/reg-exp-router'
 
-const app = new Hono()
+const app = new Hono({ router: new RegExpRouter() })
 
 const xPoweredBy = 'benchmark'
 


### PR DESCRIPTION
Hi! Great project! It would be nice to see the speed of each framework at a glance.

In this PR, I did two things:

1. Bump up the Hono version to v2.0.9
2. use `RegExpRouter` as a router. Hono has two routers. RegExpRouter is faster than the default router.

Thank you!