### PR TITLE
`singleQuote` as true in prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
     "useTabs": true,
     "trailingComma": "none",
     "semi": false,
+    "singleQuote": true,
     "tabWidth": 4
 }


### PR DESCRIPTION
Hi!

This setting is necessary to standardize whether we use single quotes or double quotes. Thanks!