### PR TITLE
add Deno script for Hono

### DIFF
--- a/src/deno/hono.ts
+++ b/src/deno/hono.ts
@@ -1,0 +1,21 @@
+import { Hono, RegExpRouter } from 'https://deno.land/x/hono@v3.2.5/mod.ts'
+
+const app = new Hono({ router: new RegExpRouter() })
+
+app.get('/', (c) => c.text('Hi'))
+	.post('/json', (c) => c.req.json().then(c.json))
+	.get('/id/:id', (c) => {
+		const id = c.req.param('id')
+		const name = c.req.query('name')
+
+		c.header('x-powered-by', 'benchmark')
+
+		return c.text(`${id} ${name}`)
+	})
+
+Deno.serve(
+	{
+		port: 3000
+	},
+	app.fetch
+)


### PR DESCRIPTION
Hi!

I've added the script for Hono on Deno. This is using `Deno.serve()`, which was stabled in version 1.35. So, please make sure to use the latest Deno. Thanks!