### PR TITLE
update script for cheetah

### DIFF
--- a/src/deno/cheetah.ts
+++ b/src/deno/cheetah.ts
@@ -1,35 +1,14 @@
-import { serve } from "https://deno.land/std@v0.186.0/http/server.ts"
+import cheetah from 'https://deno.land/x/cheetah@v1.5.0/mod.ts'
 
-import cheetah from "https://deno.land/x/cheetah@v0.5.0/mod.ts"
-import zod, { z } from "https://deno.land/x/cheetah@v0.5.0/validator/zod.ts"
+new cheetah()
+  .get('/', () => 'Hi')
+  .get(
+    '/id/:id',
+    (c) => {
+      c.res.header('x-powered-by', 'benchmark')
 
-const app = new cheetah({
-	validator: zod
-})
-	.get("/", () => "Hi")
-	.get(
-		"/id/:id",
-		{
-			query: z.object({
-				name: z.string()
-			})
-		},
-		(ctx) => {
-			ctx.res.header("x-powered-by", "benchmark")
-
-			return `${ctx.req.param("id")} ${ctx.req.query.name}`
-		}
-	)
-	.post(
-		"/json",
-		{
-			body: z.object({
-				hello: z.string()
-			})
-		},
-		(ctx) => ctx.res.json(ctx.req.body)
-	)
-
-serve(app.fetch, {
-	port: 3000
-})
+      return `${c.req.param('id')} ${(c.req.query as { name: string }).name}`
+    }
+  )
+  .post('/json', (c) => c.req.json() as Promise<{ hello: string }>)
+  .serve({ port: 3000 })


### PR DESCRIPTION
This PR updates the script for cheetah (deno).

- removes schema validation through zod
- upgrades cheetah to the latest version
- uses `Deno.serve()` under the hood, instead of the std's `serve()`

closes #44 