### PR TITLE
Add fulmine.js (node)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "elysia": "2.0.0-exp.60",
     "express": "^5.2.1",
     "fastify": "^5.10.0",
+    "fulmine.js": "^5.0.0",
     "h3": "^2.0.1-rc.26",
     "hono": "^4.12.32",
     "hyper-express": "^7.0.2",

--- a/src/node/fulmine.js
+++ b/src/node/fulmine.js
@@ -1,0 +1,34 @@
+const fulmine = require('fulmine.js')
+const { resolve } = require('node:path')
+const { extraRoutes } = require('../extra-routes.mjs')
+
+const app = fulmine()
+app.set("etag", false)
+app.set("x-powered-by", false)
+
+for (const route of extraRoutes) {
+	app.get(route, (_req, res) => res.send('ok'))
+	app.post(`${route}/submit`, (_req, res) => res.send('ok'))
+}
+
+app.get('/', (req, res) => {
+	res.setHeader('content-type', 'text/plain').send('Hi')
+})
+
+app.get('/video', (_req, res) => {
+	res.sendFile(resolve('public/kyuukurarin.mp4'), {
+		headers: { 'content-type': 'video/mp4' }
+	})
+})
+
+app.post('/json', fulmine.json(), ({ body }, res) => {
+	res.json(body)
+})
+
+app.get('/id/:id', ({ params: { id }, query: { name } }, res) => {
+	res.setHeader('x-powered-by', 'benchmark')
+		.setHeader('content-type', 'text/plain')
+		.send(`${id} ${name}`)
+})
+
+app.listen(3000, () => {})


### PR DESCRIPTION
Adds **fulmine.js** to the node group.

[fulmine.js](https://www.npmjs.com/package/fulmine.js) is an Express 5 compatible framework on µWebSockets.js, published as 5.0.0. The entry mirrors `src/node/ultimate-express.js` line for line, so the two are measured on the same code: same routes, same `etag` and `x-powered-by` off, `res.sendFile` for the video, the built-in json parser for `/json`.

Verified locally against the published package: `/` answers `Hi`, `/id/1?name=bun` answers `1 bun` with the two headers, `/json` echoes the body, `/video` streams `video/mp4`, and the extra routes answer `ok`.

The dependency is pinned `^5.0.0`, so a reinstall picks up the latest 5.x.
